### PR TITLE
[FIX] docker compose 시작 시 발생하는 포트 충돌 해결

### DIFF
--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -12,8 +12,6 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.retention.time=30d
       - --web.enable-lifecycle
-    ports:
-      - "9090:9090"
     environment:
       TZ: ${TZ}
     networks:
@@ -29,8 +27,6 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/provisioning:/etc/grafana/provisioning
-    ports:
-      - "3000:3000"
     depends_on:
       - prometheus
       - loki
@@ -46,8 +42,6 @@ services:
     volumes:
       - ./loki-config.yml:/etc/loki/config.yml:ro
       - loki-data:/loki
-    ports:
-      - "3100:3100"
     environment:
       TZ: ${TZ}
     networks:


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용
- docker-compose.yml에서 정의한 포트와 docker-compose.dev.yml에서 정의한 포트가 docker compose 시작할 때 충돌이 발생하여 docker-compose.yml에 정의한 포트를 삭제

---

## 💬 리뷰요청
- docker compose 시작 시 충돌이 발생하는 포트를 모두 삭제했습니다. 추가적인 포트 충돌이 발생할 수 있는 곳을 검토해주세요.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #4

