### PR TITLE
[FIX] Spring Security 설정에 Prometheus를 사용한 모니터링을 수행할 때 http를 사용에 필요한 접근 허용 추가

### DIFF
--- a/global/src/main/java/com/kernel/global/common/constant/SecurityUrlConstants.java
+++ b/global/src/main/java/com/kernel/global/common/constant/SecurityUrlConstants.java
@@ -18,7 +18,8 @@ public class SecurityUrlConstants  {
             "swagger-resources/**",
             "/api/common/serviceCategory",
             "/api/files/**",
-            "/api/reissue"
+            "/api/reissue",
+            "/actuator/**"
     };
 
     // 인증 필요 (로그인한 모든 사용자)


### PR DESCRIPTION
## ✅ 작업 유형

- [x] 🐛 버그 수정 (Bug Fix)

---

## 🔍 작업 내용
- dev 서버에서 prometheus로 모니터링을 시도했을 때 spring boot app에 접근하지 못하는 문제 해결
- Spring Security에서 '/actuator/**" 주소로 접근하는 것을 허용하지 않고 있어 허용 목록에 추가

---

## 💬 리뷰요청
- prometheus를 사용한 Spring boot app 모니터링을 위해 Spring Security 설정에 '/actuator/**'를 허용 목록에 추가했습니다. 이 부분을 검토해주세요.

---

## 📎 관련 이슈

<!-- 관련된 이슈 번호가 있다면 연결해주세요 -->
Closes #4 

